### PR TITLE
Validate logWarning() and logError error message format

### DIFF
--- a/lib/rules/ckeditor-error-message.js
+++ b/lib/rules/ckeditor-error-message.js
@@ -38,7 +38,7 @@ module.exports = {
 			},
 
 			CallExpression: node => {
-				if ( node.callee.type === 'Identifier' && node.callee.name === 'attachLinkToDocumentation' ) {
+				if ( node.callee.type === 'Identifier' && [ 'logWarning', 'logError' ].includes( node.callee.name ) ) {
 					validateErrorArgument( node, context );
 				}
 			}

--- a/lib/rules/ckeditor-error-message.js
+++ b/lib/rules/ckeditor-error-message.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const VALID_MESSAGE_ID = /^[a-z-0-9]+$/;
+
 module.exports = {
 	meta: {
 		type: 'problem',
@@ -31,44 +33,52 @@ module.exports = {
 				const errorName = callee.name;
 
 				if ( errorName === 'CKEditorError' ) {
-					const [ firstArgument ] = node.arguments;
-					const message = safeMessageOrNull( firstArgument );
+					validateErrorArgument( node, context );
+				}
+			},
 
-					if ( !message ) {
-						return;
-					}
-
-					if ( !isValidFormat( firstArgument ) ) {
-						context.report( {
-							node: firstArgument,
-							messageId: 'invalidMessageFormat',
-							fix: fixer => {
-								return fixer.replaceTextRange( firstArgument.range, `'${ formatMessage( message ) }'` );
-							}
-						} );
-
-						return;
-					}
-
-					// At this point CKEditorError has properly formatted errorId.
-					const errorId = message;
-
-					if ( !hasMatchingAnnotation( context.getSourceCode(), errorId ) ) {
-						context.report( {
-							node: firstArgument,
-							messageId: 'missingErrorAnnotation',
-							data: {
-								messageId: errorId
-							}
-						} );
-					}
+			CallExpression: node => {
+				if ( node.callee.type === 'Identifier' && node.callee.name === 'attachLinkToDocumentation' ) {
+					validateErrorArgument( node, context );
 				}
 			}
 		};
 	}
 };
 
-const VALID_MESSAGE_ID = /^[a-z-0-9]+$/;
+function validateErrorArgument( node, context ) {
+	const [ firstArgument ] = node.arguments;
+	const message = safeMessageOrNull( firstArgument );
+
+	if ( !message ) {
+		return;
+	}
+
+	if ( !isValidFormat( firstArgument ) ) {
+		context.report( {
+			node: firstArgument,
+			messageId: 'invalidMessageFormat',
+			fix: fixer => {
+				return fixer.replaceTextRange( firstArgument.range, `'${ formatMessage( message ) }'` );
+			}
+		} );
+
+		return;
+	}
+
+	// At this point CKEditorError has properly formatted errorId.
+	const errorId = message;
+
+	if ( !hasMatchingAnnotation( context.getSourceCode(), errorId ) ) {
+		context.report( {
+			node: firstArgument,
+			messageId: 'missingErrorAnnotation',
+			data: {
+				messageId: errorId
+			}
+		} );
+	}
+}
 
 function isValidFormat( messageNode ) {
 	if ( messageNode.type !== 'Literal' ) {

--- a/tests/ckeditor-error-messages.js
+++ b/tests/ckeditor-error-messages.js
@@ -14,6 +14,7 @@ const validJSDoc = '/**\n' +
 	' */\n';
 
 const validThrow = 'throw new CKEditorError( \'method-id-is-kebab\', this );\n';
+const validAttachLink = 'console.warn( attachLinkToDocumentation( \'method-id-is-kebab\' ) );\n';
 
 const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require( '../lib/rules/ckeditor-error-message' ), {
@@ -45,7 +46,15 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 		' *\n' +
 		' * @error unexpected-error\n' +
 		' */\n' +
-		'const error = new CKEditorError( err.message, context );\n'
+		'const error = new CKEditorError( err.message, context );\n',
+
+		validJSDoc + validAttachLink,
+
+		// Annotation in other place in the source code (before).
+		validJSDoc +
+		'if ( fooBar ) {\n' +
+		'\t' + validAttachLink +
+		'}'
 	],
 	invalid: [
 		// Deprecated message id with a semicolon after error id.
@@ -85,7 +94,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 				{ messageId: 'invalidMessageFormat' }
 			]
 		},
-		// No @error clause.
 		{
 			code:
 				'/**\n' +
@@ -106,6 +114,28 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 				' * @error some-other-error\n' +
 				' */\n' +
 				'throw new CKEditorError( \'method-id-is-kebab\', this );\n',
+			errors: [
+				{ messageId: 'missingErrorAnnotation' }
+			]
+		},
+
+		// Deprecated message id with a semicolon after error id.
+		{
+			code: validJSDoc +
+				'console.warn( attachLinkToDocumentation( \'method-id-is-kebab: Missing item.\' ) );\n',
+			output: validJSDoc + validAttachLink,
+			errors: [
+				{ messageId: 'invalidMessageFormat' }
+			]
+		},
+
+		// No @error clause.
+		{
+			code:
+				'/**\n' +
+				' * Missing item.\n' +
+				' */\n' +
+				validAttachLink,
 			errors: [
 				{ messageId: 'missingErrorAnnotation' }
 			]

--- a/tests/ckeditor-error-messages.js
+++ b/tests/ckeditor-error-messages.js
@@ -14,7 +14,8 @@ const validJSDoc = '/**\n' +
 	' */\n';
 
 const validThrow = 'throw new CKEditorError( \'method-id-is-kebab\', this );\n';
-const validAttachLink = 'console.warn( attachLinkToDocumentation( \'method-id-is-kebab\' ) );\n';
+const validConsoleWarn = 'logWarning( \'method-id-is-kebab\' );\n';
+const validConsoleError = 'logError( \'method-id-is-kebab\' );\n';
 
 const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require( '../lib/rules/ckeditor-error-message' ), {
@@ -48,12 +49,20 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 		' */\n' +
 		'const error = new CKEditorError( err.message, context );\n',
 
-		validJSDoc + validAttachLink,
+		validJSDoc + validConsoleWarn,
 
 		// Annotation in other place in the source code (before).
 		validJSDoc +
 		'if ( fooBar ) {\n' +
-		'\t' + validAttachLink +
+		'\t' + validConsoleWarn +
+		'}' +
+
+		validJSDoc + validConsoleError,
+
+		// Annotation in other place in the source code (before).
+		validJSDoc +
+		'if ( fooBar ) {\n' +
+		'\t' + validConsoleError +
 		'}'
 	],
 	invalid: [
@@ -122,8 +131,18 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 		// Deprecated message id with a semicolon after error id.
 		{
 			code: validJSDoc +
-				'console.warn( attachLinkToDocumentation( \'method-id-is-kebab: Missing item.\' ) );\n',
-			output: validJSDoc + validAttachLink,
+				'logWarning( \'method-id-is-kebab: Missing item.\' );\n',
+			output: validJSDoc + validConsoleWarn,
+			errors: [
+				{ messageId: 'invalidMessageFormat' }
+			]
+		},
+
+		// Deprecated message id with a semicolon after error id.
+		{
+			code: validJSDoc +
+				'logError( \'method-id-is-kebab: Missing item.\' );\n',
+			output: validJSDoc + validConsoleError,
 			errors: [
 				{ messageId: 'invalidMessageFormat' }
 			]
@@ -135,7 +154,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require(
 				'/**\n' +
 				' * Missing item.\n' +
 				' */\n' +
-				validAttachLink,
+				validConsoleWarn,
 			errors: [
 				{ messageId: 'missingErrorAnnotation' }
 			]


### PR DESCRIPTION
Found to be useful during work on ckeditor/ckeditor5#8124.

Probably to be merged after all other releases.