### PR TITLE
Rule that disallows direct imports of CKEditor 5 DLL packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@
 module.exports = {
 	rules: {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
-		'ckeditor-error-message': require( './rules/ckeditor-error-message' )
+		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
+		'ckeditor-dll-import': require( './rules/ckeditor-dll-import' )
 	}
 };

--- a/lib/rules/ckeditor-dll-import.js
+++ b/lib/rules/ckeditor-dll-import.js
@@ -1,0 +1,93 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+
+const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
+const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow direct imports of packages that belong to CKEditor 5 DLL.',
+			category: 'CKEditor5'
+		},
+		fixable: 'code',
+		schema: []
+	},
+	create( context ) {
+		// Short names of the packages that are included as DLL core packages.
+		// They are located inside the `src/` directory in the CKEditor 5 repository.
+		const dllPackages = context.settings.dllPackages;
+
+		if ( !dllPackages ) {
+			throw new Error(
+				'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration ' +
+				'passed as "settings.dllPackages" in the config file.'
+			);
+		}
+
+		const matchResult = context.getFilename().replace( context.getCwd(), '' ).match( SHORT_PACKAGE_NAME_PATH_REGEXP );
+		const currentFileShortPackageName = matchResult ? matchResult[ 1 ] : null;
+
+		return {
+			ImportDeclaration: node => {
+				// If the parsed package belongs to the DLL core packages, the direct import is allowed.
+				if ( dllPackages.includes( currentFileShortPackageName ) ) {
+					return;
+				}
+
+				const importPath = node.source.value;
+
+				// While importing a JS file, the extension does not have to be specified.
+				// If it is missing, Node assumes that it is '.js'.
+				const importExtension = path.extname( importPath ) || '.js';
+
+				// The rule should check only JS imports.
+				if ( importExtension !== '.js' ) {
+					return;
+				}
+
+				const matchResult = importPath.match( SHORT_PACKAGE_NAME_IMPORT_REGEXP );
+
+				if ( !matchResult ) {
+					return;
+				}
+
+				// The short package name that is being imported.
+				const shortPackageName = matchResult[ 1 ];
+
+				// If the imported package does not belong to DLL packages, let's continue.
+				if ( !dllPackages.includes( shortPackageName ) ) {
+					return;
+				}
+
+				// Otherwise, the direct import is disallowed.
+				context.report( {
+					node,
+					message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.',
+					fix: fixer => {
+						const importFixes = [
+							// Replace "@ckeditor/ckeditor5-dll/src/file" with "ckeditor5/src/dll".
+							fixer.replaceTextRange( node.source.range, `'ckeditor5/src/${ shortPackageName }'` )
+						];
+
+						const importSpecifier = node.specifiers[ 0 ];
+
+						// The default import must be changed to the named import.
+						if ( importSpecifier.type === 'ImportDefaultSpecifier' ) {
+							importFixes.push( fixer.replaceTextRange( importSpecifier.range, `{ ${ importSpecifier.local.name } }` ) );
+						}
+
+						return importFixes;
+					}
+				} );
+			}
+		};
+	}
+};

--- a/lib/rules/ckeditor-dll-import.js
+++ b/lib/rules/ckeditor-dll-import.js
@@ -8,7 +8,6 @@
 const path = require( 'path' );
 
 const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
-const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
 
 module.exports = {
 	meta: {
@@ -32,16 +31,8 @@ module.exports = {
 			);
 		}
 
-		const matchResult = context.getFilename().replace( context.getCwd(), '' ).match( SHORT_PACKAGE_NAME_PATH_REGEXP );
-		const currentFileShortPackageName = matchResult ? matchResult[ 1 ] : null;
-
 		return {
 			ImportDeclaration: node => {
-				// If the parsed package belongs to the DLL core packages, the direct import is allowed.
-				if ( dllPackages.includes( currentFileShortPackageName ) ) {
-					return;
-				}
-
 				const importPath = node.source.value;
 
 				// While importing a JS file, the extension does not have to be specified.
@@ -77,11 +68,43 @@ module.exports = {
 							fixer.replaceTextRange( node.source.range, `'ckeditor5/src/${ shortPackageName }'` )
 						];
 
-						const importSpecifier = node.specifiers[ 0 ];
+						// Import without a variable declaration.
+						// import from '...';
+						if ( !node.specifiers.length ) {
+							return importFixes;
+						}
 
-						// The default import must be changed to the named import.
-						if ( importSpecifier.type === 'ImportDefaultSpecifier' ) {
-							importFixes.push( fixer.replaceTextRange( importSpecifier.range, `{ ${ importSpecifier.local.name } }` ) );
+						const importDefaultSpecifier = findDefaultImportSpecifier( node.specifiers );
+						const importSpecifier = findImportSpecifier( node.specifiers );
+
+						// import Foo from '...'
+						if ( importDefaultSpecifier && !importSpecifier ) {
+							const defaultImportName = importDefaultSpecifier.local.name;
+
+							importFixes.push(
+								// import { Foo } from '...'
+								fixer.replaceTextRange( importDefaultSpecifier.range, `{ ${ defaultImportName } }` )
+							);
+						}
+						// import Foo, { Bar } from '...'
+						else if ( importDefaultSpecifier && importSpecifier ) {
+							const defaultImportName = importDefaultSpecifier.local.name;
+							const localImportNames = importSpecifier.local.name;
+
+							const defaultImportRange = [
+								importDefaultSpecifier.range[ 0 ],
+								importDefaultSpecifier.range[ 1 ] + 2
+							];
+
+							importFixes.push(
+								// Removes "Foo, "
+								fixer.removeRange( defaultImportRange )
+							);
+
+							importFixes.push(
+								// Adds "Foo" to local imports: { Foo, Bar }
+								fixer.replaceTextRange( importSpecifier.range, `${ defaultImportName }, ${ localImportNames }` )
+							);
 						}
 
 						return importFixes;
@@ -91,3 +114,27 @@ module.exports = {
 		};
 	}
 };
+
+/**
+ * Returns the default import specifier.
+ *
+ * @param {Array.<Object>} specifiers
+ * @returns {Object|null}
+ */
+function findDefaultImportSpecifier( specifiers ) {
+	return specifiers.find( item => {
+		return item.type === 'ImportDefaultSpecifier';
+	} );
+}
+
+/**
+ * Returns the import specifier.
+ *
+ * @param {Array.<Object>} specifiers
+ * @returns {Object|null}
+ */
+function findImportSpecifier( specifiers ) {
+	return specifiers.find( item => {
+		return item.type === 'ImportSpecifier';
+	} );
+}

--- a/tests/ckeditor-dll-import.js
+++ b/tests/ckeditor-dll-import.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const path = require( 'path' );
 const RuleTester = require( 'eslint' ).RuleTester;
 const ckeditorDllImport = require( '../lib/rules/ckeditor-dll-import' );
 
@@ -41,30 +40,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDll
 		// CSS and SVG imports should not be checked.
 		'import \'@ckeditor/ckeditor5-basic-styles/theme/bold.css\';',
 		'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
-
-		// Cross imports between DLL packages (Unix).
-		{
-			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
-			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/src/position.js'
-		},
-
-		// Cross imports between DLL packages (Windows).
-		{
-			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
-			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-engine', 'src', 'position.js' )
-		},
-
-		// Imports between non-DLL packages (Unix).
-		{
-			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
-			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-image/src/image.js'
-		},
-
-		// Imports between non-DLL packages (Windows).
-		{
-			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
-			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-image', 'src', 'image.js' )
-		}
 	],
 	invalid: [
 		{
@@ -75,6 +50,16 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDll
 		{
 			code: 'import { Plugin } from \'@ckeditor/ckeditor5-core/src/index\';',
 			output: 'import { Plugin } from \'ckeditor5/src/core\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import Plugin, { FooBar } from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			output: 'import { Plugin, FooBar } from \'ckeditor5/src/core\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import Plugin, { FooBar, Bar } from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			output: 'import { Plugin, FooBar, Bar } from \'ckeditor5/src/core\';',
 			errors: [ importError ]
 		}
 	]

--- a/tests/ckeditor-dll-import.js
+++ b/tests/ckeditor-dll-import.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const RuleTester = require( 'eslint' ).RuleTester;
+const ckeditorDllImport = require( '../lib/rules/ckeditor-dll-import' );
+
+const importError = {
+	message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.'
+};
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2018
+	},
+	settings: {
+		dllPackages: [
+			'core',
+			'engine',
+			'ui',
+			'utils',
+			'widget'
+		]
+	}
+} );
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
+	valid: [
+		// Expected imports.
+		'import { Plugin } from \'ckeditor5/src/core\';',
+		'import { first, last } from \'ckeditor5/src/utils\';',
+
+		// Unnecessary ".js" extension should not trigger an error.
+		'import { Plugin } from \'ckeditor5/src/core.js\';',
+
+		// CSS and SVG imports should not be checked.
+		'import \'@ckeditor/ckeditor5-basic-styles/theme/bold.css\';',
+		'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
+
+		// Cross imports between DLL packages (Unix).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/src/position.js'
+		},
+
+		// Cross imports between DLL packages (Windows).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-engine', 'src', 'position.js' )
+		},
+
+		// Imports between non-DLL packages (Unix).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-image/src/image.js'
+		},
+
+		// Imports between non-DLL packages (Windows).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-image', 'src', 'image.js' )
+		}
+	],
+	invalid: [
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			output: 'import { Plugin } from \'ckeditor5/src/core\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import { Plugin } from \'@ckeditor/ckeditor5-core/src/index\';',
+			output: 'import { Plugin } from \'ckeditor5/src/core\';',
+			errors: [ importError ]
+		}
+	]
+} );
+
+// The code below checks whether an error was reported if the configuration for the plugin is missing.
+try {
+	const invalidRuleTester = new RuleTester( {
+		parserOptions: {
+			sourceType: 'module',
+			ecmaVersion: 2018
+		}
+	} );
+
+	invalidRuleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
+		valid: [
+			'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';'
+		],
+		// An empty test case must be specified.
+		invalid: [ {} ]
+	} );
+} catch ( err ) {
+	const errorMessage = 'Error while loading rule \'eslint-plugin-ckeditor5-rules/ckeditor-dll-import\': ' +
+		'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration passed as "settings.dllPackages" ' +
+		'in the config file.\nOccurred while linting <input>';
+
+	if ( errorMessage !== err.message ) {
+		throw err;
+	}
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,3 +7,4 @@
 
 require( './ckeditor-error-messages' );
 require( './no-relative-imports' );
+require( './ckeditor-dll-import' );


### PR DESCRIPTION
Feature: Added a rule that disallows direct imports of packages that belong to CKEditor 5 DLL. Closes ckeditor/ckeditor5#8581.