### PR TITLE
Extended the `ckeditor-imports` rule with new directives to check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,6 @@ module.exports = {
 	rules: {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
-		'ckeditor-dll-import': require( './rules/ckeditor-dll-import' )
+		'ckeditor-imports': require( './rules/ckeditor-imports' )
 	}
 };

--- a/lib/rules/ckeditor-dll-import.js
+++ b/lib/rules/ckeditor-dll-import.js
@@ -8,6 +8,10 @@
 const path = require( 'path' );
 
 const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
+const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
+
+const DLL_IMPORT_ERROR = 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.';
+const MIXED_IMPORTS_ERROR = 'Imports between DLL and non-DLL packages are disallowed.';
 
 module.exports = {
 	meta: {
@@ -20,7 +24,7 @@ module.exports = {
 		schema: []
 	},
 	create( context ) {
-		// Short names of the packages that are included as DLL core packages.
+		// Short names of the packages that are marked as DLL packages.
 		// They are located inside the `src/` directory in the CKEditor 5 repository.
 		const dllPackages = context.settings.dllPackages;
 
@@ -31,110 +35,151 @@ module.exports = {
 			);
 		}
 
+		const matchResult = context.getFilename().replace( context.getCwd(), '' ).match( SHORT_PACKAGE_NAME_PATH_REGEXP );
+		const currentFileShortPackageName = matchResult ? matchResult[ 1 ] : null;
+
 		return {
 			ImportDeclaration: node => {
 				const importPath = node.source.value;
-
-				// While importing a JS file, the extension does not have to be specified.
-				// If it is missing, Node assumes that it is '.js'.
-				const importExtension = path.extname( importPath ) || '.js';
-
-				// The rule should check only JS imports.
-				if ( importExtension !== '.js' ) {
-					return;
-				}
-
 				const matchResult = importPath.match( SHORT_PACKAGE_NAME_IMPORT_REGEXP );
 
+				// If the short package name was not found, it means that 3rd party package or local file is being imported. It is fine.
 				if ( !matchResult ) {
 					return;
 				}
 
-				// The short package name that is being imported.
 				const shortPackageName = matchResult[ 1 ];
 
-				// If the imported package does not belong to DLL packages, let's continue.
-				if ( !dllPackages.includes( shortPackageName ) ) {
-					return;
+				// Checks whether the current parsed file belong to DLL package.
+				if ( isPartOfDllPackages( currentFileShortPackageName ) ) {
+					// Allows cross importing between DLL packages.
+					if ( isPartOfDllPackages( shortPackageName ) ) {
+						return;
+					}
+
+					// DLL package cannot import non-DLL package. ESLint cannot fix the error.
+					return context.report( {
+						node,
+						message: MIXED_IMPORTS_ERROR
+					} );
 				}
 
-				// Otherwise, the direct import is disallowed.
-				context.report( {
+				// If the imported package does not belong to DLL packages, report an error that ESLint cannot fix automatically.
+				if ( !isPartOfDllPackages( shortPackageName ) ) {
+					return context.report( {
+						node,
+						message: MIXED_IMPORTS_ERROR
+					} );
+				}
+
+				// Otherwise, if the imported source is a JS file, allow fixing the error by ESLint.
+				const reportObject = {
 					node,
-					message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.',
-					fix: fixer => {
-						const importFixes = [
-							// Replace "@ckeditor/ckeditor5-dll/src/file" with "ckeditor5/src/dll".
-							fixer.replaceTextRange( node.source.range, `'ckeditor5/src/${ shortPackageName }'` )
-						];
+					message: DLL_IMPORT_ERROR,
+					fix: fixerFactory( node, shortPackageName )
+				};
 
-						// Import without a variable declaration.
-						// import from '...';
-						if ( !node.specifiers.length ) {
-							return importFixes;
-						}
+				// While importing the JS file, the extension does not have to be specified.
+				// If it is missing, Node assumes that it is '.js'.
+				const importExtension = path.extname( importPath ) || '.js';
 
-						const importDefaultSpecifier = findDefaultImportSpecifier( node.specifiers );
-						const importSpecifier = findImportSpecifier( node.specifiers );
+				// The fixer should try to fix the JS file only.
+				if ( importExtension !== '.js' ) {
+					delete reportObject.fix;
+				}
 
-						// import Foo from '...'
-						if ( importDefaultSpecifier && !importSpecifier ) {
-							const defaultImportName = importDefaultSpecifier.local.name;
-
-							importFixes.push(
-								// import { Foo } from '...'
-								fixer.replaceTextRange( importDefaultSpecifier.range, `{ ${ defaultImportName } }` )
-							);
-						}
-						// import Foo, { Bar } from '...'
-						else if ( importDefaultSpecifier && importSpecifier ) {
-							const defaultImportName = importDefaultSpecifier.local.name;
-							const localImportNames = importSpecifier.local.name;
-
-							const defaultImportRange = [
-								importDefaultSpecifier.range[ 0 ],
-								importDefaultSpecifier.range[ 1 ] + 2
-							];
-
-							importFixes.push(
-								// Removes "Foo, "
-								fixer.removeRange( defaultImportRange )
-							);
-
-							importFixes.push(
-								// Adds "Foo" to local imports: { Foo, Bar }
-								fixer.replaceTextRange( importSpecifier.range, `${ defaultImportName }, ${ localImportNames }` )
-							);
-						}
-
-						return importFixes;
-					}
-				} );
+				context.report( reportObject );
 			}
 		};
+
+		/**
+		 * Returns the default import specifier.
+		 *
+		 * @param {Array.<Object>} specifiers
+		 * @returns {Object|null}
+		 */
+		function findDefaultImportSpecifier( specifiers ) {
+			return specifiers.find( item => {
+				return item.type === 'ImportDefaultSpecifier';
+			} );
+		}
+
+		/**
+		 * Returns the import specifier.
+		 *
+		 * @param {Array.<Object>} specifiers
+		 * @returns {Object|null}
+		 */
+		function findImportSpecifier( specifiers ) {
+			return specifiers.find( item => {
+				return item.type === 'ImportSpecifier';
+			} );
+		}
+
+		/**
+		 * Checks whether the specified package belongs to the DLL packages.
+		 *
+		 * @param {String|null} packageToCheck
+		 * @returns {Boolean}
+		 */
+		function isPartOfDllPackages( packageToCheck ) {
+			if ( !packageToCheck ) {
+				return false;
+			}
+
+			return dllPackages.includes( packageToCheck );
+		}
+
+		/**
+		 * Returns a callback that will be used by ESlint. It attempts to fix the problem that was reported.
+		 *
+		 * @param {Object} node
+		 * @param {String} shortPackageName
+		 * @returns {Function}
+		 */
+		function fixerFactory( node, shortPackageName ) {
+			return fixer => {
+				const importFixes = [
+					// Replace "@ckeditor/ckeditor5-dll/src/file" with "ckeditor5/src/dll".
+					fixer.replaceTextRange( node.source.range, `'ckeditor5/src/${ shortPackageName }'` )
+				];
+
+				// Import without a variable declaration.
+				// import from '...';
+				if ( !node.specifiers.length ) {
+					return importFixes;
+				}
+
+				const importDefaultSpecifier = findDefaultImportSpecifier( node.specifiers );
+				const importSpecifier = findImportSpecifier( node.specifiers );
+
+				// import Foo from '...'
+				if ( importDefaultSpecifier && !importSpecifier ) {
+					const defaultImportName = importDefaultSpecifier.local.name;
+
+					// import { Foo } from '...'
+					importFixes.push( fixer.replaceTextRange( importDefaultSpecifier.range, `{ ${ defaultImportName } }` ) );
+				}
+				// import Foo, { Bar } from '...'
+				else if ( importDefaultSpecifier && importSpecifier ) {
+					const defaultImportName = importDefaultSpecifier.local.name;
+					const localImportNames = importSpecifier.local.name;
+
+					const defaultImportRange = [
+						importDefaultSpecifier.range[ 0 ],
+						importDefaultSpecifier.range[ 1 ] + 2
+					];
+
+					// Removes "Foo, "
+					importFixes.push( fixer.removeRange( defaultImportRange ) );
+
+					// Adds "Foo" to local imports: { Foo, Bar }
+					importFixes.push( fixer.replaceTextRange( importSpecifier.range, `${ defaultImportName }, ${ localImportNames }` ) );
+				}
+
+				return importFixes;
+			};
+		}
 	}
 };
 
-/**
- * Returns the default import specifier.
- *
- * @param {Array.<Object>} specifiers
- * @returns {Object|null}
- */
-function findDefaultImportSpecifier( specifiers ) {
-	return specifiers.find( item => {
-		return item.type === 'ImportDefaultSpecifier';
-	} );
-}
-
-/**
- * Returns the import specifier.
- *
- * @param {Array.<Object>} specifiers
- * @returns {Object|null}
- */
-function findImportSpecifier( specifiers ) {
-	return specifiers.find( item => {
-		return item.type === 'ImportSpecifier';
-	} );
-}

--- a/lib/rules/ckeditor-imports.js
+++ b/lib/rules/ckeditor-imports.js
@@ -30,7 +30,7 @@ module.exports = {
 
 		if ( !dllPackages ) {
 			throw new Error(
-				'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration ' +
+				'The "ckeditor5-rules/ckeditor-imports" rule requires additional configuration ' +
 				'passed as "settings.dllPackages" in the config file.'
 			);
 		}

--- a/lib/rules/ckeditor-imports.js
+++ b/lib/rules/ckeditor-imports.js
@@ -10,8 +10,8 @@ const path = require( 'path' );
 const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
 const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
 
-const DLL_IMPORT_ERROR = 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.';
-const MIXED_IMPORTS_ERROR = 'Imports between DLL and non-DLL packages are disallowed.';
+const DLL_IMPORT_ERROR = 'Imports from DLL packages must be done using the "ckeditor5" package.';
+const MIXED_IMPORTS_ERROR = 'Imports from a non-DLL package are not allowed.';
 
 module.exports = {
 	meta: {
@@ -182,4 +182,3 @@ module.exports = {
 		}
 	}
 };
-

--- a/tests/ckeditor-dll-import.js
+++ b/tests/ckeditor-dll-import.js
@@ -5,11 +5,16 @@
 
 'use strict';
 
+const path = require( 'path' );
 const RuleTester = require( 'eslint' ).RuleTester;
 const ckeditorDllImport = require( '../lib/rules/ckeditor-dll-import' );
 
-const importError = {
+const DLL_IMPORT_ERROR = {
 	message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.'
+};
+
+const MIXED_IMPORTS_ERROR = {
+	message: 'Imports between DLL and non-DLL packages are disallowed.'
 };
 
 const ruleTester = new RuleTester( {
@@ -34,59 +39,159 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDll
 		'import { Plugin } from \'ckeditor5/src/core\';',
 		'import { first, last } from \'ckeditor5/src/utils\';',
 
-		// Unnecessary ".js" extension should not trigger an error.
+		// Unnecessary ".js" extension the import itself is correct.
 		'import { Plugin } from \'ckeditor5/src/core.js\';',
 
-		// CSS and SVG imports should not be checked.
-		'import \'@ckeditor/ckeditor5-basic-styles/theme/bold.css\';',
-		'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
+		// Cross imports between DLL packages (Unix).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-engine/src/position.js'
+		},
+
+		// Cross imports between DLL packages (Windows).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-engine', 'src', 'position.js' )
+		}
 	],
 	invalid: [
+		// Invalid imports and corrected code.
 		{
 			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
 			output: 'import { Plugin } from \'ckeditor5/src/core\';',
-			errors: [ importError ]
+			errors: [ DLL_IMPORT_ERROR ]
 		},
 		{
 			code: 'import { Plugin } from \'@ckeditor/ckeditor5-core/src/index\';',
 			output: 'import { Plugin } from \'ckeditor5/src/core\';',
-			errors: [ importError ]
+			errors: [ DLL_IMPORT_ERROR ]
 		},
+
+		// Import the default export and named variables should be merged into single object.
 		{
 			code: 'import Plugin, { FooBar } from \'@ckeditor/ckeditor5-core/src/plugin\';',
 			output: 'import { Plugin, FooBar } from \'ckeditor5/src/core\';',
-			errors: [ importError ]
+			errors: [ DLL_IMPORT_ERROR ]
 		},
 		{
 			code: 'import Plugin, { FooBar, Bar } from \'@ckeditor/ckeditor5-core/src/plugin\';',
 			output: 'import { Plugin, FooBar, Bar } from \'ckeditor5/src/core\';',
-			errors: [ importError ]
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+
+		// Imports between non-DLL packages (Unix).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-image/src/image.js',
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Imports between non-DLL packages (Windows).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-image', 'src', 'image.js' ),
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Imports non-DLL package from DLL package (Unix).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-core/src/plugin.js',
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Imports non-DLL package from DLL package (Windows).
+		{
+			code: 'import Bold from \'@ckeditor/ckeditor5-basic-styles/src/bold\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.js' ),
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Imports DLL package from non-DLL package (Unix).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			output: 'import { Plugin } from \'ckeditor5/src/core\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-basic-styles/src/bold.js',
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+
+		// Imports DLL package from non-DLL package (Windows).
+		{
+			code: 'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';',
+			output: 'import { Plugin } from \'ckeditor5/src/core\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+
+		// CSS & SVG imports between DLL and non-DLL packages aren't allowed (Unix).
+		{
+			code: 'import \'@ckeditor/ckeditor5-basic-styles/theme/bold.css\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-core/src/plugin.js',
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		{
+			code: 'import okIcon from \'@ckeditor/ckeditor5-basic-styles/theme/icons/ok.svg\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-core/src/plugin.js',
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Fixer tries to fix JS imports only.
+		{
+			code: 'import \'@ckeditor/ckeditor5-core/theme/editor.css\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-basic-styles/src/bold.js',
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+		{
+			code: 'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-basic-styles/src/bold.js',
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+
+		// CSS & SVG imports between DLL and non-DLL packages aren't allowed (Windows).
+		{
+			code: 'import \'@ckeditor/ckeditor5-basic-styles/theme/bold.css\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.js' ),
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		{
+			code: 'import okIcon from \'@ckeditor/ckeditor5-basic-styles/theme/icons/ok.svg\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.js' ),
+			errors: [ MIXED_IMPORTS_ERROR ]
+		},
+
+		// Fixer tries to fix JS imports only.
+		{
+			code: 'import \'@ckeditor/ckeditor5-core/theme/editor.css\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
+			errors: [ DLL_IMPORT_ERROR ]
+		},
+		{
+			code: 'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
+			errors: [ DLL_IMPORT_ERROR ]
 		}
 	]
 } );
 
 // The code below checks whether an error was reported if the configuration for the plugin is missing.
-try {
-	const invalidRuleTester = new RuleTester( {
-		parserOptions: {
-			sourceType: 'module',
-			ecmaVersion: 2018
+( ruleTester => {
+	try {
+		ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
+			valid: [
+				'import { Plugin } from \'ckeditor5/src/core\';'
+			],
+			// An empty test case must be specified.
+			invalid: [ {} ]
+		} );
+	} catch ( err ) {
+		const errorMessage = 'Error while loading rule \'eslint-plugin-ckeditor5-rules/ckeditor-dll-import\': ' +
+			'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration passed as "settings.dllPackages" ' +
+			'in the config file.\nOccurred while linting <input>';
+
+		if ( errorMessage !== err.message ) {
+			throw err;
 		}
-	} );
-
-	invalidRuleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
-		valid: [
-			'import Plugin from \'@ckeditor/ckeditor5-core/src/plugin\';'
-		],
-		// An empty test case must be specified.
-		invalid: [ {} ]
-	} );
-} catch ( err ) {
-	const errorMessage = 'Error while loading rule \'eslint-plugin-ckeditor5-rules/ckeditor-dll-import\': ' +
-		'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration passed as "settings.dllPackages" ' +
-		'in the config file.\nOccurred while linting <input>';
-
-	if ( errorMessage !== err.message ) {
-		throw err;
 	}
-}
+} )( new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } ) );

--- a/tests/ckeditor-imports.js
+++ b/tests/ckeditor-imports.js
@@ -10,11 +10,11 @@ const RuleTester = require( 'eslint' ).RuleTester;
 const ckeditorImports = require( '../lib/rules/ckeditor-imports' );
 
 const DLL_IMPORT_ERROR = {
-	message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.'
+	message: 'Imports from DLL packages must be done using the "ckeditor5" package.'
 };
 
 const MIXED_IMPORTS_ERROR = {
-	message: 'Imports between DLL and non-DLL packages are disallowed.'
+	message: 'Imports from a non-DLL package are not allowed.'
 };
 
 const ruleTester = new RuleTester( {

--- a/tests/ckeditor-imports.js
+++ b/tests/ckeditor-imports.js
@@ -7,7 +7,7 @@
 
 const path = require( 'path' );
 const RuleTester = require( 'eslint' ).RuleTester;
-const ckeditorDllImport = require( '../lib/rules/ckeditor-dll-import' );
+const ckeditorImports = require( '../lib/rules/ckeditor-imports' );
 
 const DLL_IMPORT_ERROR = {
 	message: 'Imports of packages that belong to CKEditor 5 DLL should be done using the "ckeditor5" package.'
@@ -33,7 +33,7 @@ const ruleTester = new RuleTester( {
 	}
 } );
 
-ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-imports', ckeditorImports, {
 	valid: [
 		// Expected imports.
 		'import { Plugin } from \'ckeditor5/src/core\';',
@@ -178,7 +178,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDll
 // The code below checks whether an error was reported if the configuration for the plugin is missing.
 ( ruleTester => {
 	try {
-		ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDllImport, {
+		ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-imports', ckeditorImports, {
 			valid: [
 				'import { Plugin } from \'ckeditor5/src/core\';'
 			],
@@ -186,8 +186,8 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-dll-import', ckeditorDll
 			invalid: [ {} ]
 		} );
 	} catch ( err ) {
-		const errorMessage = 'Error while loading rule \'eslint-plugin-ckeditor5-rules/ckeditor-dll-import\': ' +
-			'The "ckeditor5-rules/ckeditor-dll-import" rule requires additional configuration passed as "settings.dllPackages" ' +
+		const errorMessage = 'Error while loading rule \'eslint-plugin-ckeditor5-rules/ckeditor-imports\': ' +
+			'The "ckeditor5-rules/ckeditor-imports" rule requires additional configuration passed as "settings.dllPackages" ' +
 			'in the config file.\nOccurred while linting <input>';
 
 		if ( errorMessage !== err.message ) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -7,4 +7,4 @@
 
 require( './ckeditor-error-messages' );
 require( './no-relative-imports' );
-require( './ckeditor-dll-import' );
+require( './ckeditor-imports' );


### PR DESCRIPTION
Other: Renamed the rule from `ckeditor5-rules/ckeditor-dll-import` to `ckeditor5-rules/ckeditor-imports`. Closes ckeditor/ckeditor5#8824.

Feature: Extended the `ckeditor5-rules/ckeditor-imports` rule. Now the imports listed below are allowed:

- from 3rd party things,
- directly from within the same package,
- via `@ckeditor/ckeditor5-*` format from DLL package,
- via `ckeditor5/src/*` format for non-DLL package.

Imports non-DLL packages are not allowed. Those rules apply to JS, CSS, and SVG files.

---

Do not forget about applying the changes below after releasing the new version of the package:

```diff
diff --git a/.eslintrc.js b/.eslintrc.js
index 9cbb982dd5..380a714247 100644
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,20 +17,20 @@ module.exports = {
 		dllPackages
 	},
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'error'
+		'ckeditor5-rules/ckeditor-imports': 'error'
 	},
 	overrides: [
 		{
 			files: [ '**/tests/**/*.js' ],
 			rules: {
 				'no-unused-expressions': 'off',
-				'ckeditor5-rules/ckeditor-dll-import': 'off'
+				'ckeditor5-rules/ckeditor-imports': 'off'
 			}
 		},
 		{
 			files: [ '**/docs/**/*.js' ],
 			rules: {
-				'ckeditor5-rules/ckeditor-dll-import': 'off'
+				'ckeditor5-rules/ckeditor-imports': 'off'
 			}
 		}
 	]
diff --git a/packages/ckeditor5-build-balloon-block/.eslintrc.js b/packages/ckeditor5-build-balloon-block/.eslintrc.js
index 6a89ffac94..8f63c92875 100644
--- a/packages/ckeditor5-build-balloon-block/.eslintrc.js
+++ b/packages/ckeditor5-build-balloon-block/.eslintrc.js
@@ -9,6 +9,6 @@
 
 module.exports = {
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'off'
+		'ckeditor5-rules/ckeditor-imports': 'off'
 	}
 };
diff --git a/packages/ckeditor5-build-balloon/.eslintrc.js b/packages/ckeditor5-build-balloon/.eslintrc.js
index 6a89ffac94..8f63c92875 100644
--- a/packages/ckeditor5-build-balloon/.eslintrc.js
+++ b/packages/ckeditor5-build-balloon/.eslintrc.js
@@ -9,6 +9,6 @@
 
 module.exports = {
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'off'
+		'ckeditor5-rules/ckeditor-imports': 'off'
 	}
 };
diff --git a/packages/ckeditor5-build-classic/.eslintrc.js b/packages/ckeditor5-build-classic/.eslintrc.js
index 6a89ffac94..8f63c92875 100644
--- a/packages/ckeditor5-build-classic/.eslintrc.js
+++ b/packages/ckeditor5-build-classic/.eslintrc.js
@@ -9,6 +9,6 @@
 
 module.exports = {
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'off'
+		'ckeditor5-rules/ckeditor-imports': 'off'
 	}
 };
diff --git a/packages/ckeditor5-build-decoupled-document/.eslintrc.js b/packages/ckeditor5-build-decoupled-document/.eslintrc.js
index 6a89ffac94..8f63c92875 100644
--- a/packages/ckeditor5-build-decoupled-document/.eslintrc.js
+++ b/packages/ckeditor5-build-decoupled-document/.eslintrc.js
@@ -9,6 +9,6 @@
 
 module.exports = {
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'off'
+		'ckeditor5-rules/ckeditor-imports': 'off'
 	}
 };
diff --git a/packages/ckeditor5-build-inline/.eslintrc.js b/packages/ckeditor5-build-inline/.eslintrc.js
index 6a89ffac94..8f63c92875 100644
--- a/packages/ckeditor5-build-inline/.eslintrc.js
+++ b/packages/ckeditor5-build-inline/.eslintrc.js
@@ -9,6 +9,6 @@
 
 module.exports = {
 	rules: {
-		'ckeditor5-rules/ckeditor-dll-import': 'off'
+		'ckeditor5-rules/ckeditor-imports': 'off'
 	}
 };
diff --git a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
index b24d2975b3..bf0d311469 100644
--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
@@ -21,6 +21,9 @@ import { FocusTracker, KeystrokeHandler } from 'ckeditor5/src/utils';
 import { icons } from 'ckeditor5/src/core';
 
 import '../../../theme/textalternativeform.css';
+
+// See: #8833.
+// eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 
 /**
diff --git a/packages/ckeditor5-link/src/ui/linkactionsview.js b/packages/ckeditor5-link/src/ui/linkactionsview.js
index 4050ce7ada..12642f5033 100644
--- a/packages/ckeditor5-link/src/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.js
@@ -13,6 +13,8 @@ import { icons } from 'ckeditor5/src/core';
 
 import { ensureSafeUrl } from '../utils';
 
+// See: #8833.
+// eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/linkactions.css';
 
diff --git a/packages/ckeditor5-link/src/ui/linkformview.js b/packages/ckeditor5-link/src/ui/linkformview.js
index f3ab2c6153..5342b977ba 100644
--- a/packages/ckeditor5-link/src/ui/linkformview.js
+++ b/packages/ckeditor5-link/src/ui/linkformview.js
@@ -21,6 +21,8 @@ import {
 import { FocusTracker, KeystrokeHandler } from 'ckeditor5/src/utils';
 import { icons } from 'ckeditor5/src/core';
 
+// See: #8833.
+// eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/linkform.css';
 
diff --git a/packages/ckeditor5-media-embed/src/ui/mediaformview.js b/packages/ckeditor5-media-embed/src/ui/mediaformview.js
index 30754d09f7..196d78c17a 100644
--- a/packages/ckeditor5-media-embed/src/ui/mediaformview.js
+++ b/packages/ckeditor5-media-embed/src/ui/mediaformview.js
@@ -20,6 +20,8 @@ import {
 import { FocusTracker, KeystrokeHandler } from 'ckeditor5/src/utils';
 import { icons } from 'ckeditor5/src/core';
 
+// See: #8833.
+// eslint-disable-next-line ckeditor5-rules/ckeditor-imports
 import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.css';
 import '../../theme/mediaform.css';
```