### PR TITLE
ckeditor/ckeditor5#9181: Drafted some rules for JSDoc comment validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ module.exports = {
 	rules: {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
-		'ckeditor-imports': require( './rules/ckeditor-imports' )
+		'ckeditor-imports': require( './rules/ckeditor-imports' ),
+		'ckeditor-jsdoc-comments': require( './rules/ckeditor-jsdoc-comments' )
 	}
 };

--- a/lib/rules/ckeditor-jsdoc-comments.js
+++ b/lib/rules/ckeditor-jsdoc-comments.js
@@ -1,0 +1,153 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const JSDOC_COMMENT_START_REGEXP = /^\*\n/g;
+
+const JSDOC_COMMENT_MULTIPLE_EMPTY_LINES_REGEXP = /^$/g;
+const JSDOC_COMMENT_TOO_FEW_TABS_REGEXP = /^\t[^\t]/g;
+const JSDOC_COMMENT_MIXED_INDENT_REGEXP = /(\t \t| \t )/g;
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Enforce JSDoc formatting practices in CKEditor 5 project.',
+			category: 'CKEditor5'
+		},
+		messages: {
+			noMultipleEmptyLines: 'Two empty comment line should not be next to each other.',
+			codeExampleTooFewTabs: 'Code example content should be indented by at least two tabs.',
+			codeExampleMixedIndent: 'Tabs and spaces should not be mixed in the code example indentation.'
+		}
+	},
+	create( context ) {
+		return {
+			Program() {
+				const sourceCode = context.getSourceCode();
+				const commentCheckers = {
+					'code-example-too-few-tabs': ( comment, parsedComment ) => {
+						getMatchingLines( parsedComment, JSDOC_COMMENT_TOO_FEW_TABS_REGEXP ).forEach( line => {
+							// Does not apply to the last line.
+							if ( line.index === parsedComment.length - 1 ) {
+								return;
+							}
+
+							const relativePos = lineMatchToRelativePositionInComment( comment, line );
+
+							context.report( {
+								loc: movePostitionByRelative( comment.loc, relativePos ),
+								messageId: 'codeExampleTooFewTabs'
+							} );
+						} );
+					},
+
+					'code-example-no-mixed-white-space': ( comment, parsedComment ) => {
+						getMatchingLines( parsedComment, JSDOC_COMMENT_MIXED_INDENT_REGEXP ).forEach( line => {
+							const relativePos = lineMatchToRelativePositionInComment( comment, line );
+
+							context.report( {
+								loc: movePostitionByRelative( comment.loc, relativePos ),
+								messageId: 'codeExampleMixedIndent'
+							} );
+						} );
+					},
+
+					'no-multiple-empty-lines': ( comment, parsedComment ) => {
+						let previousEmptyLineIndex;
+
+						getMatchingLines( parsedComment, JSDOC_COMMENT_MULTIPLE_EMPTY_LINES_REGEXP ).forEach( line => {
+							if ( previousEmptyLineIndex !== undefined && line.index === previousEmptyLineIndex + 1 ) {
+								const relativePos = lineMatchToRelativePositionInComment( comment, line );
+
+								context.report( {
+									loc: movePostitionByRelative( comment.loc, relativePos ),
+									messageId: 'noMultipleEmptyLines'
+								} );
+							}
+
+							previousEmptyLineIndex = line.index;
+						} );
+					}
+				};
+
+				return sourceCode.getAllComments()
+					// Filter inline "// foo" and "# foo" comments out.
+					.filter( comment => comment.type !== 'Shebang' && comment.type !== 'Line' )
+
+					// Filter comments that don't start with "/**" out.
+					.filter( comment => comment.value.match( JSDOC_COMMENT_START_REGEXP ) )
+
+					// Filter one-liners out.
+					.filter( comment => comment.loc.start.line !== comment.loc.end.line )
+
+					.forEach( comment => {
+						const parsedComment = parseComment( comment );
+
+						for ( const checkerName in commentCheckers ) {
+							commentCheckers[ checkerName ]( comment, parsedComment );
+						}
+					} );
+			}
+		};
+	}
+};
+
+function getMatchingLines( parsedComment, regexp ) {
+	return parsedComment
+		.map( line => {
+			const match = regexp.exec( line.value );
+
+			if ( match ) {
+				return { ...line, match };
+			}
+
+			return line;
+		} )
+		.filter( line => line.match );
+}
+
+function movePostitionByRelative( pos, relativePos ) {
+	return {
+		start: { line: pos.start.line + relativePos.line, column: pos.start.column + relativePos.column },
+		end: { line: pos.start.line + relativePos.line, column: pos.start.column + relativePos.column + 1 }
+	};
+}
+
+function parseComment( comment ) {
+	return parseCommentLines( comment )
+		.map( ( { value, startOffset }, index ) => {
+			return {
+				value: value.replace( /^\s*\*/g, '' ),
+				startOffset,
+				index
+			};
+		} );
+}
+
+function parseCommentLines( comment ) {
+	const commentLines = comment.value.split( '\n' );
+	const parsedLines = [];
+
+	let startOffset = 0;
+
+	for ( const line of commentLines ) {
+		parsedLines.push( {
+			startOffset,
+			value: line
+		} );
+
+		startOffset += line.length + 1; // Mind the \n
+	}
+
+	return parsedLines;
+}
+
+function lineMatchToRelativePositionInComment( comment, line ) {
+	const lineMatch = line.match;
+
+	return { line: line.index, column: lineMatch.index + 2 }; // 2 compensates " *"
+}


### PR DESCRIPTION
Feature: Introduced ESLint rules for common JSDoc issues. Closes ckeditor/ckeditor5#9181.

---

To check this pr, best symlink the entire repo on this branch and change the following in the ckeditor5 root `.eslintrc`

```diff
diff --git a/.eslintrc.js b/.eslintrc.js
index 880651d7f4..147cd5b7d5 100644
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
                   dllPackages
          },
          rules: {
-                  'ckeditor5-rules/ckeditor-imports': 'error'
+                  'ckeditor5-rules/ckeditor-imports': 'error',
+                  'ckeditor5-rules/ckeditor-jsdoc-comments': 'error'
          },
          overrides: [
                   {
```

 P.S. remember to restart your IDE, at least VSCode caches ESLint configs. You can also test it using CLI:

```
node_modules/.bin/eslint  packages/**/*.js -f codeframe --quiet
```

---

TODO:

*   overeager evaludation for nested lists `packages/ckeditor5-engine/src/conversion/conversion.js:142:4`
*   tests