### PR TITLE
Disallow importing from other dirs than "src" when importing from ckeditor5

### DIFF
--- a/lib/rules/ckeditor-imports.js
+++ b/lib/rules/ckeditor-imports.js
@@ -60,7 +60,6 @@ module.exports = {
 					return;
 				}
 
-
 				const shortPackageName = matchResult[ 1 ];
 
 				// If the current parsed package belongs to DLL, all (DLL and non-DLL) imports are allowed.

--- a/lib/rules/ckeditor-imports.js
+++ b/lib/rules/ckeditor-imports.js
@@ -9,8 +9,10 @@ const path = require( 'path' );
 
 const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
 const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
+const CKEDITOR5_PACKAGE_IMPORT_REGEXP = /ckeditor5\/(?!src)/;
 
 const DLL_IMPORT_ERROR = 'Imports from DLL packages must be done using the "ckeditor5" package.';
+const CKEDITOR5_INVALID_IMPORT = 'Imports from the `ckeditor5` package must use the `src/` directory.';
 
 module.exports = {
 	meta: {
@@ -42,10 +44,22 @@ module.exports = {
 				const importPath = node.source.value;
 				const matchResult = importPath.match( SHORT_PACKAGE_NAME_IMPORT_REGEXP );
 
+				// Do not allow importing from the `ckeditor5` package from other directories than `src/`.
+				// See: https://github.com/ckeditor/ckeditor5/issues/10030.
+				if ( importPath.match( CKEDITOR5_PACKAGE_IMPORT_REGEXP ) ) {
+					context.report( {
+						node,
+						message: CKEDITOR5_INVALID_IMPORT
+					} );
+
+					return;
+				}
+
 				// If the short package name was not found, it means that 3rd party package or local file is being imported. It is fine.
 				if ( !matchResult ) {
 					return;
 				}
+
 
 				const shortPackageName = matchResult[ 1 ];
 

--- a/tests/ckeditor-imports.js
+++ b/tests/ckeditor-imports.js
@@ -13,6 +13,10 @@ const DLL_IMPORT_ERROR = {
 	message: 'Imports from DLL packages must be done using the "ckeditor5" package.'
 };
 
+const CKEDITOR5_INVALID_IMPORT = {
+	message: 'Imports from the `ckeditor5` package must use the `src/` directory.'
+};
+
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
@@ -159,6 +163,18 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-imports', ckeditorImport
 			code: 'import okIcon from \'@ckeditor/ckeditor5-core/theme/icons/ok.svg\';',
 			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
 			errors: [ DLL_IMPORT_ERROR ]
+		},
+
+		// Importing from other directories than `src/` from the `ckeditor5` package.
+		{
+			code: 'import \'ckeditor5/packages/ckeditor5-ui/theme/components/responsive-form/responsiveform.css\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-basic-styles/src/bold.js',
+			errors: [ CKEDITOR5_INVALID_IMPORT ]
+		},
+		{
+			code: 'import \'ckeditor5/packages/ckeditor5-ui/theme/components/responsive-form/responsiveform.css\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
+			errors: [ CKEDITOR5_INVALID_IMPORT ]
 		}
 	]
 } );


### PR DESCRIPTION
Fix: Disallow importing from other directories than "src/" when importing from the "ckeditor5" package. Closes ckeditor/ckeditor5#10030.