### PR TITLE
Import between DLL packages must use the full name of the imported package

### DIFF
--- a/lib/rules/ckeditor-imports.js
+++ b/lib/rules/ckeditor-imports.js
@@ -7,12 +7,21 @@
 
 const path = require( 'path' );
 
+// A regular expression for determining the short name of a package from a full package name.
 const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
+
+// A regular expression for determining the short name of a package from its name without the scope.
 const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
+
+// A regular expression for determining whether an imported path uses the `src/` directory.
 const CKEDITOR5_PACKAGE_IMPORT_REGEXP = /ckeditor5\/(?!src)/;
+
+// A regular expression for determining the short package name when importing using the `ckeditor5` package.
+const CKEDITOR5_SHORT_PACKAGE_NAME_REGEXP = /ckeditor5\/src\/(.*)/;
 
 const DLL_IMPORT_ERROR = 'Imports from DLL packages must be done using the "ckeditor5" package.';
 const CKEDITOR5_INVALID_IMPORT = 'Imports from the `ckeditor5` package must use the `src/` directory.';
+const DLL_USE_FULL_NAME_IMPORT = 'Imports between DLL packages must use full package name.';
 
 module.exports = {
 	meta: {
@@ -55,17 +64,32 @@ module.exports = {
 					return;
 				}
 
-				// If the short package name was not found, it means that 3rd party package or local file is being imported. It is fine.
+				const isCurrentFileInDllPackage = isPartOfDllPackages( currentFileShortPackageName );
+
+				// If the current processed file belongs to one of the DLL packages...
+				if ( isCurrentFileInDllPackage ) {
+					// ...and importing other DLL package, it must use the full path of the package instead of the `ckeditor5` package.
+					// See: https://github.com/ckeditor/ckeditor5/issues/10375.
+
+					const shortNameImportedPackage = importPath.match( CKEDITOR5_SHORT_PACKAGE_NAME_REGEXP );
+
+					if ( shortNameImportedPackage ) {
+						context.report( {
+							node,
+							message: DLL_USE_FULL_NAME_IMPORT
+						} );
+					}
+
+					// Otherwise, do not check anything as DLL packages can import dependencies without limitations.
+					return;
+				}
+
+				// Importing a file within the same package or 3rd party package. It's fine.
 				if ( !matchResult ) {
 					return;
 				}
 
 				const shortPackageName = matchResult[ 1 ];
-
-				// If the current parsed package belongs to DLL, all (DLL and non-DLL) imports are allowed.
-				if ( isPartOfDllPackages( currentFileShortPackageName ) ) {
-					return;
-				}
 
 				// Allows importing non-DLL packages.
 				if ( !isPartOfDllPackages( shortPackageName ) ) {

--- a/tests/ckeditor-imports.js
+++ b/tests/ckeditor-imports.js
@@ -17,6 +17,10 @@ const CKEDITOR5_INVALID_IMPORT = {
 	message: 'Imports from the `ckeditor5` package must use the `src/` directory.'
 };
 
+const DLL_USE_FULL_NAME_IMPORT = {
+	message: 'Imports between DLL packages must use full package name.'
+};
+
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
@@ -175,6 +179,18 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-imports', ckeditorImport
 			code: 'import \'ckeditor5/packages/ckeditor5-ui/theme/components/responsive-form/responsiveform.css\';',
 			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-basic-styles', 'src', 'bold.js' ),
 			errors: [ CKEDITOR5_INVALID_IMPORT ]
+		},
+
+		// Importing DLL package by DLL package without using its full names.
+		{
+			code: 'import { Plugin } from \'ckeditor5/src/core\';',
+			filename: '/Users/Workspace/ckeditor/ckeditor5/packages/ckeditor5-widget/src/plugin.js',
+			errors: [ DLL_USE_FULL_NAME_IMPORT ]
+		},
+		{
+			code: 'import { Plugin } from \'ckeditor5/src/core\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-widget', 'src', 'plugin.js' ),
+			errors: [ DLL_USE_FULL_NAME_IMPORT ]
 		}
 	]
 } );


### PR DESCRIPTION
Other: An import between DLL packages must use the full name of the imported package. Closes ckeditor/ckeditor5#10375.