### PR TITLE
Created a linter rule that disallows adding cross-package imports in the ckeditor5-watchdog package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 yarn.lock
+node_modules

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ module.exports = {
 	rules: {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
-		'ckeditor-imports': require( './rules/ckeditor-imports' )
+		'ckeditor-imports': require( './rules/ckeditor-imports' ),
+		'no-cross-package-imports': require('./rules/no-cross-package-imports')
 	}
 };

--- a/lib/rules/no-cross-package-imports.js
+++ b/lib/rules/no-cross-package-imports.js
@@ -8,38 +8,38 @@
 const CROSS_PACKAGE_IMPORT = /^ckeditor5/;
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        docs: {
-            description: 'Disallow cross-package imports from CKEditor5 in specified packages.',
-            category: 'CKEditor5'
-        },
-        schema: []
-    },
-    create( context ) {
-        return {
-            ImportDeclaration: node => {
-                const targetPackages = context.settings.disallowedCrossImportsPackages;
-                const packagePath = context.getFilename().replace( context.getCwd(), '' );
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow cross-package imports from CKEditor5 in specified packages.',
+			category: 'CKEditor5'
+		},
+		schema: []
+	},
+	create( context ) {
+		return {
+			ImportDeclaration: node => {
+				const targetPackages = context.settings.disallowedCrossImportsPackages;
+				const packagePath = context.getFilename().replace( context.getCwd(), '' );
 
-                const isPackageTargeted = targetPackages.some( pack => {
-                    return packagePath.includes( pack );
-                } );
+				const isPackageTargeted = targetPackages.some( pack => {
+					return packagePath.includes( pack );
+				} );
 
-                if ( !isPackageTargeted ) {
-                    return;
-                }
+				if ( !isPackageTargeted ) {
+					return;
+				}
 
-                const importPath = node.source.value;
-                const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath );
+				const importPath = node.source.value;
+				const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath );
 
-                if ( isCrossImport ) {
-                    context.report( {
-                        node,
-                        message: 'Adding cross-package imports in this package is disabled.'
-                    } );
-                }
-            }
-        };
-    }
+				if ( isCrossImport ) {
+					context.report( {
+						node,
+						message: 'Adding cross-package imports in this package is disabled.'
+					} );
+				}
+			}
+		};
+	}
 };

--- a/lib/rules/no-cross-package-imports.js
+++ b/lib/rules/no-cross-package-imports.js
@@ -20,20 +20,20 @@ module.exports = {
         return {
             ImportDeclaration: node => {
                 const targetPackages = context.settings.disallowedCrossImportsPackages;
-                const packagePath = context.getFilename().replace( context.getCwd(), '');
+                const packagePath = context.getFilename().replace( context.getCwd(), '' );
 
-                const isPackageTargeted = targetPackages.some((pack)=>{
-                    return packagePath.includes(pack)
-                })
+                const isPackageTargeted = targetPackages.some( pack => {
+                    return packagePath.includes( pack );
+                } );
 
-                if (!isPackageTargeted) {
-                    return
+                if ( !isPackageTargeted ) {
+                    return;
                 }
 
                 const importPath = node.source.value;
-                const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath )
+                const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath );
 
-                if ( isCrossImport  ) {
+                if ( isCrossImport ) {
                     context.report( {
                         node,
                         message: 'Adding cross-package imports in this package is disabled.'

--- a/lib/rules/no-cross-package-imports.js
+++ b/lib/rules/no-cross-package-imports.js
@@ -5,14 +5,13 @@
 
 'use strict';
 
-const CROSS_PACKAGE_IMPORT = /import.+from 'ckeditor5.+';/g;
-const WATCHDOG_FILE = /ckeditor5-watchdog/;
+const CROSS_PACKAGE_IMPORT = /^ckeditor5/;
 
 module.exports = {
     meta: {
         type: 'problem',
         docs: {
-            description: 'Disallow cross-package imports from CKEditor5 packages in the ckeditor5-watchdog package.',
+            description: 'Disallow cross-package imports from CKEditor5 in specified packages.',
             category: 'CKEditor5'
         },
         schema: []
@@ -20,14 +19,24 @@ module.exports = {
     create( context ) {
         return {
             ImportDeclaration: node => {
+                const targetPackages = context.settings.disallowedCrossImportsPackages;
+                const packagePath = context.getFilename().replace( context.getCwd(), '');
+
+                const isPackageTargeted = targetPackages.some((pack)=>{
+                    return packagePath.includes(pack)
+                })
+
+                if (!isPackageTargeted) {
+                    return
+                }
+
                 const importPath = node.source.value;
                 const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath )
-                const isWatchdogFile = context.getFilename().replace( context.getCwd(), '' ).match( WATCHDOG_FILE );
 
-                if ( isCrossImport && isWatchdogFile ) {
+                if ( isCrossImport  ) {
                     context.report( {
                         node,
-                        message: 'Adding cross-package imports in the ckeditor5-watchdog is not allowed.'
+                        message: 'Adding cross-package imports in this package is disabled.'
                     } );
                 }
             }

--- a/lib/rules/no-cross-package-imports.js
+++ b/lib/rules/no-cross-package-imports.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const CROSS_PACKAGE_IMPORT = /import.+from 'ckeditor5.+';/g;
+const WATCHDOG_FILE = /ckeditor5-watchdog/;
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow cross-package imports from CKEditor5 packages in the ckeditor5-watchdog package.',
+            category: 'CKEditor5'
+        },
+        schema: []
+    },
+    create( context ) {
+        return {
+            ImportDeclaration: node => {
+                const importPath = node.source.value;
+                const isCrossImport = CROSS_PACKAGE_IMPORT.test( importPath )
+                const isWatchdogFile = context.getFilename().replace( context.getCwd(), '' ).match( WATCHDOG_FILE );
+
+                if ( isCrossImport && isWatchdogFile ) {
+                    context.report( {
+                        node,
+                        message: 'Adding cross-package imports in the ckeditor5-watchdog is not allowed.'
+                    } );
+                }
+            }
+        };
+    }
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,12 @@
 
 'use strict';
 
-require( './ckeditor-error-messages' );
-require( './no-relative-imports' );
-require( './ckeditor-imports' );
+const fs = require( 'fs' );
+
+const tests = fs.readdirSync( __dirname ).filter( test => {
+    return test !== 'index.js';
+} );
+
+for ( const test of tests ) {
+    require( `./${ test }` );
+}

--- a/tests/no-cross-package-imports.js
+++ b/tests/no-cross-package-imports.js
@@ -5,18 +5,106 @@
 
 'use strict';
 
+const path = require( 'path' );
 const RuleTester = require( 'eslint' ).RuleTester;
-const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2018
+	}, settings: {
+		disallowedCrossImportsPackages: [
+			'ckeditor5-watchdog'
+		]
+	}
+} );
 
 const importError = { message: 'Adding cross-package imports in this package is disabled.' };
-const context = { settings: { disallowedCrossImportsPackages: [ 'ckeditor5-watchdog' ] } };
 
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-cross-package-imports', require( '../lib/rules/no-cross-package-imports' ), {
-    valid: [/*
-        'import Watchdog from \'./watchdog\';',
-        'import EditorWatchdog from \'./editorwatchdog\';',
-        'import areConnectedThroughProperties from \'./utils/areconnectedthroughproperties\';',
-        'import getSubNodes from \'./utils/getsubnodes\';'
-    */],
-    invalid: []
+	valid: [
+		/**
+		 * Windows style path
+		 */
+
+		// Non-cross package imports in disallowed package
+		{
+			code: 'import Watchdog from \'./watchdog\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import EditorWatchdog from \'./editorwatchdog\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import areConnectedThroughProperties from \'./utils/areconnectedthroughproperties\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import getSubNodes from \'./utils/getsubnodes\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		// Cross package imports in allowed package
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.js' )
+		},
+		// Other file formats
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.css' )
+		},
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.svg' )
+		},
+
+		/**
+		 * Unix style path
+		 */
+
+		// Non-cross package imports in disallowed package
+		{
+			code: 'import Watchdog from \'./watchdog\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import EditorWatchdog from \'./editorwatchdog\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import areConnectedThroughProperties from \'./utils/areconnectedthroughproperties\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		{
+			code: 'import getSubNodes from \'./utils/getsubnodes\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' )
+		},
+		// Cross package imports in allowed package
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.js' )
+		},
+		// Other file formats
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.css' )
+		},
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'plugin.svg' )
+		}
+	],
+	invalid: [
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.win32.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' ),
+			errors: [ importError ]
+		},
+		{
+			code: 'import { toArray } from \'ckeditor5/src/utils\';',
+			filename: path.posix.join( 'C:', 'Workspace', 'ckeditor', 'ckeditor5', 'packages', 'ckeditor5-watchdog', 'src', 'plugin.js' ),
+			errors: [ importError ]
+		}
+	]
 } );

--- a/tests/no-cross-package-imports.js
+++ b/tests/no-cross-package-imports.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+
+const importError = { message: 'Adding cross-package imports in this package is disabled.' };
+const context = { settings: { disallowedCrossImportsPackages: [ 'ckeditor5-watchdog' ] } };
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-cross-package-imports', require( '../lib/rules/no-cross-package-imports' ), {
+    valid: [/*
+        'import Watchdog from \'./watchdog\';',
+        'import EditorWatchdog from \'./editorwatchdog\';',
+        'import areConnectedThroughProperties from \'./utils/areconnectedthroughproperties\';',
+        'import getSubNodes from \'./utils/getsubnodes\';'
+    */],
+    invalid: []
+} );


### PR DESCRIPTION
Other: Created a linter rule that disallows adding cross-package imports in the ckeditor5-watchdog package. Closes ckeditor/ckeditor5#9318.