### PR TITLE
Introduced the `license-header` rule to check `@license`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Configure ESLint with a `.eslintrc` file using the following contents:
 		'ckeditor5-rules' // Add the plugin to the linter.
 	],
 	rules: {
-		'ckeditor5-rules/no-relative-imports': 'error'
+		'ckeditor5-rules/no-relative-imports': 'error',
+		'ckeditor5-rules/license-header': [ 'error', {
+			headerLines: [
+				'/**',
+				' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+				' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
+				' */'
+			]
+		} ]
 		// ...
 	}
 	// ...
@@ -42,6 +50,23 @@ import Position from '../../ckeditor5-engine/src/model/position';
 
 // Will be fix to: 
 import Position from '@ckeditor/ckeditor5-engine/src/model/position';
+```
+
+### license-header
+
+This rule checks if each file starts with proper `@license` block comment. It requires configuration:
+
+```js
+rules: {
+	'ckeditor5-rules/license-header': [ 'error', {
+		headerLines: [
+			'/**',
+			' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+			' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
+			' */'
+		]
+	} ]
+}
 ```
 
 ## Changelog

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-imports': require( './rules/ckeditor-imports' ),
-		'no-cross-package-imports': require('./rules/no-cross-package-imports')
+		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
+		'license-header': require( './rules/license-header' )
 	}
 };

--- a/lib/rules/license-header.js
+++ b/lib/rules/license-header.js
@@ -1,0 +1,106 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'layout',
+		docs: {
+			description: 'Enforce the presence of a @license header.',
+			category: 'CKEditor5'
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					headerLines: {
+						type: 'array'
+					}
+				},
+				additionalProperties: false
+			}
+		]
+	},
+
+	create( context ) {
+		const [ { headerLines } = {} ] = context.options;
+
+		if ( !headerLines ) {
+			console.error( 'The license-header rule is missing the "headerLines" configuration.' );
+		}
+
+		const headerHeight = headerLines.length;
+		const headerText = headerLines.join( '\n' );
+		const sourceCode = context.getSourceCode();
+		const sourceText = sourceCode.getText();
+
+		return {
+			Program( node ) {
+				const leadingComments = sourceCode.getComments( node.body[ 0 ] || node ).leading;
+				const leadingComment = leadingComments.find( comment => comment.type === 'Block' );
+				const isLeadingCommentALicenseComment = leadingComment &&
+					sourceCode.getText( leadingComment ).toLowerCase().includes( '@license' );
+
+				if ( isLeadingCommentALicenseComment ) {
+					const leadingCommentText = sourceCode.getText( leadingComment );
+
+					if ( leadingCommentText !== headerText ) {
+						context.report( {
+							node: leadingComment,
+							message: 'The license header is incorrect.'
+						} );
+					}
+
+					if ( leadingComment.loc.start.line > 1 ) {
+						context.report( {
+							loc: {
+								start: {
+									line: 0,
+									column: 0
+								},
+								end: {
+									line: 0,
+									column: 1
+								}
+							},
+							message: 'There is an extra new line before the license header.'
+						} );
+					}
+
+					if ( sourceText.trimStart().slice( leadingCommentText.length, leadingCommentText.length + 2 ) !== '\n\n' ) {
+						context.report( {
+							loc: {
+								start: {
+									line: headerHeight,
+									column: 0
+								},
+								end: {
+									line: headerHeight,
+									column: 0
+								}
+							},
+							message: 'There is a new line missing after the license header.'
+						} );
+					}
+				} else {
+					context.report( {
+						loc: {
+							start: {
+								line: 0,
+								column: 0
+							},
+							end: {
+								line: 0,
+								column: 0
+							}
+						},
+						message: 'The license header is missing.'
+					} );
+				}
+			}
+		};
+	}
+};

--- a/lib/rules/license-header.js
+++ b/lib/rules/license-header.js
@@ -35,11 +35,11 @@ module.exports = {
 		const headerHeight = headerLines.length;
 		const headerText = headerLines.join( '\n' );
 		const sourceCode = context.getSourceCode();
-		const sourceText = sourceCode.getText();
 
 		return {
 			Program( node ) {
 				const leadingComments = sourceCode.getComments( node.body[ 0 ] || node ).leading;
+				const leadingShebang = leadingComments.find( comment => comment.type === 'Shebang' );
 				const leadingComment = leadingComments.find( comment => comment.type === 'Block' );
 				const isLeadingCommentALicenseComment = leadingComment &&
 					sourceCode.getText( leadingComment ).toLowerCase().includes( '@license' );
@@ -54,7 +54,7 @@ module.exports = {
 						} );
 					}
 
-					if ( leadingComment.loc.start.line > 1 ) {
+					if ( !leadingShebang && leadingComment.loc.start.line > 1 ) {
 						context.report( {
 							loc: {
 								start: {
@@ -70,7 +70,7 @@ module.exports = {
 						} );
 					}
 
-					if ( sourceText.trimStart().slice( leadingCommentText.length, leadingCommentText.length + 2 ) !== '\n\n' ) {
+					if ( sourceCode.lines[ leadingComment.loc.end.line ] != '' ) {
 						context.report( {
 							loc: {
 								start: {

--- a/tests/license-header.js
+++ b/tests/license-header.js
@@ -1,0 +1,140 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const extraLineBeforeError = { message: 'There is an extra new line before the license header.' };
+const newLineAfterMissingError = { message: 'There is a new line missing after the license header.' };
+const incorrectHeaderError = { message: 'The license header is incorrect.' };
+const missingHeaderError = { message: 'The license header is missing.' };
+
+const options = [ {
+	headerLines: [
+		'/**',
+		' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+		' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
+		' */'
+	]
+} ];
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2018
+	}
+} );
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/license-header', require( '../lib/rules/license-header' ), {
+	valid: [
+		{
+			code:
+`/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+foo()`,
+			options
+		}
+	],
+	invalid: [
+		{
+			code:
+`
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+foo()`,
+			options,
+			errors: [ extraLineBeforeError ]
+		},
+		{
+			code:
+`
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+foo()`,
+			options,
+			errors: [ extraLineBeforeError, newLineAfterMissingError ]
+		},
+		{
+			code:
+`/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+foo()`,
+			options,
+			errors: [ newLineAfterMissingError ]
+		},
+		{
+			code:
+`
+/**
+ * @license TODO
+ */`,
+			options,
+			errors: [ extraLineBeforeError, incorrectHeaderError, newLineAfterMissingError ]
+		},
+		{
+			code:
+`/**
+ * @LICENSE COPYRIGHT (C) 2003-2022, CKSOURCE HOLDING SP. Z O.O. ALL RIGHTS RESERVED.
+ * FOR LICENSING, SEE LICENSE.MD OR HTTPS://CKEDITOR.COM/LEGAL/CKEDITOR-OSS-LICENSE
+ */
+
+foo()`,
+			options,
+			errors: [ incorrectHeaderError ]
+		},
+		{
+			code:
+`/**
+ * ------------------------ Same length but different content -----------------------
+ * ----------------------- Same length but different content ----------------------
+ */
+foo()`,
+			options,
+			errors: [ missingHeaderError ]
+		},
+		{
+			code:
+`// @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+// For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+
+foo()`,
+			options,
+			errors: [ missingHeaderError ]
+		},
+		{
+			code:
+`/** foo */
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+foo()`,
+			options,
+			errors: [ missingHeaderError ] // Not the best, not the worst.
+		},
+		{
+			code: 'foo()',
+			options,
+			errors: [ missingHeaderError ]
+		},
+		{
+			code: '',
+			options,
+			errors: [ missingHeaderError ]
+		}
+	]
+} );

--- a/tests/license-header.js
+++ b/tests/license-header.js
@@ -39,8 +39,34 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/license-header', require( '../lib
 
 foo()`,
 			options
+		},
+		{
+			code:
+`#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+foo()`,
+			options
+		},
+		{
+			code:
+`#!/usr/bin/env node
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+foo()`,
+			options
 		}
 	],
+
+	// -----------------------------------------------------------------------------------------------------
+
 	invalid: [
 		{
 			code:
@@ -83,6 +109,15 @@ foo()`,
  */`,
 			options,
 			errors: [ extraLineBeforeError, incorrectHeaderError, newLineAfterMissingError ]
+		},
+		{
+			code:
+`/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */`,
+			options,
+			errors: [ newLineAfterMissingError ]
 		},
 		{
 			code:


### PR DESCRIPTION
Feature: Introduced the `license-header` rule to check `@license` comments in JS files. Closes ckeditor/ckeditor5#6082.

---

*   For the record, I didn't use any of the existing solutions because they looked overcomplicated, didn't allow configuration in `.eslintrc` and/or looked fairly unpopular.
*   I didn't implement automatic fixers in the MVP.